### PR TITLE
Fix Linux tray icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "files": [
       "**/*",
       "build/icon.ico",
-      "build/notification_icon.ico"
+      "build/icon.png",
+      "build/notification_icon.ico",
+      "build/notification_icon.png"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
this PR adds `icon.png` and `notification_icon.png` to the files list for `electron-builder`, so the app's icon is properly displayed on Linux

(fixes #1)